### PR TITLE
Update email from semanticbits address

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,8 @@ Each user/organization is responsible for conducting their own review and testin
 **Asking for Help**
 
 If you continue to have issues accessing production or have follow up questions not answered in this guide, please
-email the AB2D team at ab2d@semanticbits.com or join our Google Groups at: [https://groups.google.com/u/1/g/cms-ab2d-api](https://groups.google.com/u/1/g/cms-ab2d-api).
+email the AB2D team at [ab2d@cms.hhs.gov](mailto:ab2d@cms.hhs.gov) or join our Google Groups at:
+[https://groups.google.com/u/1/g/cms-ab2d-api](https://groups.google.com/u/1/g/cms-ab2d-api).
 
 When corresponding with the team please include the following information concerning the context of your issue:
 

--- a/docs/Production Access.md
+++ b/docs/Production Access.md
@@ -17,9 +17,8 @@ The most sensitive information provided in the credential file includes:
 ## Asking for Help
 
 If you continue to have issues accessing production or have follow-up questions not answered in this guide, please
-email the AB2D team at [ab2d@semanticbits.com](mailto:ab2d@semanticbits.com) 
-or join our Google Groups at: 
-[https://groups.google.com/u/1/g/cms-ab2d-api](https://groups.google.com/u/1/g/cms-ab2d-api). 
+email the AB2D team at [ab2d@cms.hhs.gov](mailto:ab2d@cms.hhs.gov) or join our Google Groups at:
+[https://groups.google.com/u/1/g/cms-ab2d-api](https://groups.google.com/u/1/g/cms-ab2d-api).
 
 When corresponding with the team please include the following information concerning the context of your issue:
 


### PR DESCRIPTION
Noticed we were still pointing at the ab2d@semanticbits.com email in these docs.